### PR TITLE
Fixed calling 'update' with an empty extent

### DIFF
--- a/math/extent.hpp
+++ b/math/extent.hpp
@@ -144,8 +144,8 @@ inline void update(Extent_<T> &e, const T &x) {
 
 template <typename T>
 inline void update(Extent_<T> &e, const Extent_<T> &other) {
-    update(e, other.l);
-    update(e, other.r);
+    e.l = std::min(e.l, other.l);
+    e.r = std::max(e.r, other.r);
 }
 
 template <typename T, typename U>


### PR DESCRIPTION
The current implementation of `update` yields unexpected result when called with empty `Extent`.

E.g.:
```cpp
math::Extent e1(0, 1);
math::Extent e2(math::InvalidExtents{});
math::update(e1, e2);
// e1 is now (-infinity, infinity)
```

PR changes this to leave the `Extent` unchanged in such cases.