### PR TITLE
using ublas::fixed_vector<T> to implement math::PointX_<T>

### DIFF
--- a/math/detail/point.inline.hpp
+++ b/math/detail/point.inline.hpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2020 Melown Technologies SE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *  Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file detail/point.inline.hpp
+ * @author Vaclav Blazek <vaclav.blazek@melowntech.com>
+ *
+ * Point I/O.
+ * Do not include directly!
+ */
+
+#ifndef MATH_GEOMETRY_CORE_HPP_INLINES_
+#    error Do not include this implementation header directly!
+#endif
+
+template<class E, class T, class PT>
+std::basic_istream<E, T>&
+operator>>(std::basic_istream<E, T> &is, Point2_<PT> &v)
+{
+    ublas::vector<PT, ublas::bounded_array<PT, 2>> tmp;
+    is >> tmp;
+    v = tmp;
+    return is;
+}
+
+template<class E, class T, class PT>
+std::basic_istream<E, T>&
+operator>>(std::basic_istream<E, T> &is, Point3_<PT> &v)
+{
+    ublas::vector<PT, ublas::bounded_array<PT, 3>> tmp;
+    is >> tmp;
+    v = tmp;
+    return is;
+}
+
+template<class E, class T, class PT>
+std::basic_istream<E, T>&
+operator>>(std::basic_istream<E, T> &is, Point4_<PT> &v)
+{
+    ublas::vector<PT, ublas::bounded_array<PT, 4>> tmp;
+    is >> tmp;
+    v = tmp;
+    return is;
+}

--- a/math/geometry_core.hpp
+++ b/math/geometry_core.hpp
@@ -261,32 +261,33 @@ inline bool inside(const Viewport2_<T1> &v, T2 x, T2 y)
 /* points and point vectors */
 
 template <class T>
-class Point2_ : public ublas::vector<T, ublas::bounded_array<T, 2> > {
+class Point2_ : public ublas::fixed_vector<T, 2>  {
+    using Base = ublas::fixed_vector<T, 2>;
 public:
     Point2_( const T & x = 0.0, const T & y = 0.0 )
-        : ublas::vector<T, ublas::bounded_array<T, 2> >(2) {
+        : Base() {
         (*this)(0) = x; (*this)(1) = y;
     }
 
     template <class AE>
     Point2_( const ublas::vector_expression<AE> & op )
-        : ublas::vector<T, ublas::bounded_array<T, 2> >(2) {
+        : Base() {
         ublas::vector_assign<ublas::scalar_assign>(*this, op );
     }
 
     Point2_( const ublas::vector<T> & op )
-        : ublas::vector<T, ublas::bounded_array<T, 2> >(2) {
+        : Base() {
         ublas::vector_assign<ublas::scalar_assign>( *this, op );
     }
 
 #ifdef MATH_HAS_OPENCV
     Point2_( const cv::Point_<T> & op )
-        : ublas::vector<T, ublas::bounded_array<T, 2> >(2) {
+        : Base() {
         (*this)(0) = op.x; (*this)(1) = op.y;
     }
 
     Point2_(const cv::Vec<T,2>& op)
-        : ublas::vector<T, ublas::bounded_array<T, 2> >(2) {
+        : Base() {
         (*this)(0) = op[0]; (*this)(1) = op[1];
     }
 #endif
@@ -301,7 +302,7 @@ public:
 
     template <typename U>
     explicit Point2_(const Point2_<U> &op)
-        : ublas::vector<T, ublas::bounded_array<T, 2> >(2)
+        : Base()
     {
         (*this)(0) = op(0); (*this)(1) = op(1);
     }
@@ -315,33 +316,34 @@ public:
 };
 
 template <class T>
-class Point3_ : public ublas::vector<T, ublas::bounded_array<T, 3> > {
+class Point3_ : public ublas::fixed_vector<T, 3> {
+    using Base = ublas::fixed_vector<T, 3>;
 public:
     Point3_( const T & x = 0.0, const T & y = 0.0, const T & z = 0.0 )
-        : ublas::vector<T, ublas::bounded_array<T, 3> >(3) {
+        : Base() {
         (*this)(0) = x; (*this)(1) = y; (*this)(2) = z;
     }
 
     template <class AE>
     Point3_( const ublas::vector_expression<AE> & op )
-        : ublas::vector<T, ublas::bounded_array<T, 3> >(3) {
+        : Base() {
         ublas::vector_assign<ublas::scalar_assign>( *this, op );
     }
 
     Point3_( const ublas::vector<T> & op )
-        : ublas::vector<T, ublas::bounded_array<T, 3> >(3) {
+        : Base() {
         ublas::vector_assign<ublas::scalar_assign>( *this, op );
     }
 
 #ifdef MATH_HAS_OPENCV
     // convieniece for reading points from 3-channel OpenCV matrices
     Point3_(const cv::Vec<T,3>& op)
-        : ublas::vector<T, ublas::bounded_array<T, 3> >(3) {
+        : Base() {
         (*this)(0) = op[0]; (*this)(1) = op[1]; (*this)(2) = op[2];
     }
 
     Point3_(const cv::Point3_<T>& op)
-        : ublas::vector<T, ublas::bounded_array<T, 3> >(3) {
+        : Base() {
         (*this)(0) = op.x; (*this)(1) = op.y; (*this)(2) = op.z;
     }
 #endif
@@ -351,7 +353,7 @@ public:
 
     // make point movable
     Point3_( Point3_<T> && op )
-        : ublas::vector<T, ublas::bounded_array<T, 3> >(3) {
+        : Base() {
         ublas::vector_assign<ublas::scalar_assign>( *this, op );
     }
 
@@ -362,7 +364,7 @@ public:
 
     template <typename U>
     explicit Point3_(const Point3_<U> &op)
-        : ublas::vector<T, ublas::bounded_array<T, 3> >(3)
+        : Base()
     {
         (*this)(0) = op(0); (*this)(1) = op(1); (*this)(2) = op(2);
     }
@@ -376,22 +378,23 @@ public:
 };
 
 template <class T>
-class Point4_ : public ublas::vector<T, ublas::bounded_array<T, 4> > {
+class Point4_ : public ublas::fixed_vector<T, 4> {
+    using Base = ublas::fixed_vector<T, 4>;
 public:
     Point4_( const T & x = 0.0, const T & y = 0.0
            , const T & z = 0.0, const T & w = 0.0 )
-        : ublas::vector<T, ublas::bounded_array<T, 4> >(4) {
+        : Base() {
         (*this)(0) = x; (*this)(1) = y; (*this)(2) = z; (*this)(3) = w;
     }
 
     template <class AE>
     Point4_( const ublas::vector_expression<AE> & op )
-        : ublas::vector<T, ublas::bounded_array<T, 4> >(4) {
+        : Base() {
         ublas::vector_assign<ublas::scalar_assign>( *this, op );
     }
 
     Point4_( const ublas::vector<T> & op )
-        : ublas::vector<T, ublas::bounded_array<T, 4> >(4) {
+        : Base() {
         ublas::vector_assign<ublas::scalar_assign>( *this, op );
     }
 
@@ -1207,6 +1210,7 @@ const Point3_<T>& point3(const Point3_<T> &p) { return p; }
 
 
 #define MATH_GEOMETRY_CORE_HPP_INLINES_
+#include "detail/point.inline.hpp"
 #include "detail/size2.inline.hpp"
 #include "detail/size3.inline.hpp"
 #include "detail/extents2.inline.hpp"


### PR DESCRIPTION
`math::PointN_<T>` types based on `boost::ublas::fixed_vector<T, N>` which does not contain `size` field, i.e. `sizeof(math::PointN_<T>)` yields N*sizeof(T).

NB: `opertator>>` had to be implemeted using temporary `boost::ublas::vector` (`operator<<` works out of the box since it accepts `boost::ublas::vector_expression`).

Still WIP:
 * needs to be thoroughly tested
 * `boost::serialization` support must be checked and updated if broken by this changed
 