### PR TITLE
New plane representation, plane- and line-related functions

### DIFF
--- a/math/geometry.cpp
+++ b/math/geometry.cpp
@@ -141,8 +141,8 @@ double pointPlaneDistance(const Point3& p, const Plane3& plane)
 
 Point3 pointPlaneProjection(const Point3& p, const Plane3& plane)
 {
-    double k
-        = (ublas::inner_prod(plane.n_, p) + plane.d_) / ublas::norm_2(plane.n_);
+    double k = (ublas::inner_prod(plane.n_, p) + plane.d_)
+               / ublas::norm_2_square(plane.n_);
 
     return Point3(p(0) - k * plane.n_(0),
                   p(1) - k * plane.n_(1),

--- a/math/geometry.cpp
+++ b/math/geometry.cpp
@@ -170,6 +170,29 @@ Line3 planeIntersection(const Plane3& p1, const Plane3& p2)
     return Line3(pt, crossProduct(n1, n2));
 }
 
+Point3 planeIntersection(const Plane3& p1, const Plane3& p2, const Plane3& p3)
+{
+    Matrix3 D = ublas::zero_matrix<double>(3, 3);
+    ublas::row(D, 0) = p1.n_;
+    ublas::row(D, 1) = p2.n_;
+    ublas::row(D, 2) = p3.n_;
+
+    Point3 p(-p1.d_, -p2.d_, -p3.d_);
+
+    Matrix3 Dx = D;
+    ublas::column(Dx, 0) = p;
+    Matrix3 Dy = D;
+    ublas::column(Dy, 1) = p;
+    Matrix3 Dz = D;
+    ublas::column(Dz, 2) = p;
+
+    double den = determinant(D);
+
+    return Point3(determinant(Dx) / den,
+                  determinant(Dy) / den,
+                  determinant(Dz) / den);
+}
+
 double polygonRegularity(
     const Point3 & v0, const Point3 & v1, const Point3 & v2  ) {
 

--- a/math/geometry.cpp
+++ b/math/geometry.cpp
@@ -149,6 +149,13 @@ Point3 pointPlaneProjection(const Point3& p, const Plane3& plane)
                   p(2) - k * plane.n_(2));
 }
 
+Point3 linePlaneIntersection(const Line3& l, const Plane3& plane)
+{
+    double t = (-ublas::inner_prod(plane.n_, l.p) - plane.d_)
+               / (ublas::inner_prod(plane.n_, l.u));
+    return l.p + t * l.u;
+}
+
 Line3 planeIntersection(const Plane3& p1, const Plane3& p2)
 {
     // normalize plane representation

--- a/math/geometry.cpp
+++ b/math/geometry.cpp
@@ -149,6 +149,27 @@ Point3 pointPlaneProjection(const Point3& p, const Plane3& plane)
                   p(2) - k * plane.n_(2));
 }
 
+Line3 planeIntersection(const Plane3& p1, const Plane3& p2)
+{
+    // normalize plane representation
+    double norm1 = ublas::norm_2(p1.n_);
+    Point3 n1 = p1.n_ / norm1;
+    double d1 = p1.d_ / norm1;
+
+    double norm2 = ublas::norm_2(p2.n_);
+    Point3 n2 = p2.n_ / norm2;
+    double d2 = p2.d_ / norm2;
+
+    // get one point on line
+    double n1n2 = ublas::inner_prod(n1, n2);   
+    double den = 1 - std::pow(n1n2, 2);
+    double c1 = ((d2 * n1n2) - d1) / den;
+    double c2 = ((d1 * n1n2) - d2) / den;
+    Point3 pt = c1 * n1 + c2 * n2;
+
+    return Line3(pt, crossProduct(n1, n2));
+}
+
 double polygonRegularity(
     const Point3 & v0, const Point3 & v1, const Point3 & v2  ) {
 

--- a/math/geometry.cpp
+++ b/math/geometry.cpp
@@ -112,7 +112,7 @@ double pointLineDistance(const Point3 &p, const Line3 &line)
 }
 
 
-Point3 intersectionParams(const Line3 &line, const Plane3 &plane)
+Point3 intersectionParams(const Line3 &line, const legacy::Plane3 &plane)
 {
     ublas::matrix<double> a( 3, 3 ), ai( 3, 3 );
     ublas::vector<double> op( 3 ), pars( 3 );
@@ -128,7 +128,7 @@ Point3 intersectionParams(const Line3 &line, const Plane3 &plane)
     return pars;
 }
 
-Point3 intersection( const Line3 & line, const Plane3 & plane )
+Point3 intersection( const Line3 & line, const legacy::Plane3 & plane )
 {
     return line.point(intersectionParams(line, plane)(0));
 }

--- a/math/geometry.cpp
+++ b/math/geometry.cpp
@@ -133,6 +133,21 @@ Point3 intersection( const Line3 & line, const legacy::Plane3 & plane )
     return line.point(intersectionParams(line, plane)(0));
 }
 
+double pointPlaneDistance(const Point3& p, const Plane3& plane)
+{
+    return std::abs(ublas::inner_prod(plane.n_, p) + plane.d_)
+           / ublas::norm_2(plane.n_);
+}
+
+Point3 pointPlaneProjection(const Point3& p, const Plane3& plane)
+{
+    double k
+        = (ublas::inner_prod(plane.n_, p) + plane.d_) / ublas::norm_2(plane.n_);
+
+    return Point3(p(0) - k * plane.n_(0),
+                  p(1) - k * plane.n_(1),
+                  p(2) - k * plane.n_(2));
+}
 
 double polygonRegularity(
     const Point3 & v0, const Point3 & v1, const Point3 & v2  ) {

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -96,6 +96,19 @@ inline double length( const T & v ) {
     return ublas::norm_2(v);
 }
 
+/** angle between two 3D vectors (in radians)
+ * See Kahan W.: How Futile are Mindless Assessments of Roundoff in
+ * Floating-Point Computation?, page 46
+ * (https://people.eecs.berkeley.edu/~wkahan/Mindless.pdf)
+ *  **/
+template <class T>
+inline T angle(const Point3_<T>& v1, const Point3_<T>& v2)
+{
+    return 2
+           * std::atan2(length(v1 * length(v2) - length(v1) * v2),
+                        length(v1 * length(v2) + length(v1) * v2));
+}
+
 /** homogeneous coordinates (from euclidian) */
 template <class T>
 inline ublas::vector<T, ublas::bounded_array<T, 4> >

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <array>
 
+#include <boost/optional/optional_io.hpp>
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/vector_proxy.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
@@ -255,14 +256,18 @@ struct Line2_
 typedef Line2_<Point2> Line2;
 
 /** Returns a point where two lines `l1` and `l2` intersect.
- * Point is inf
+ * Returns none if lines are parallel (exactly).
  */
-template<typename T>
-inline T lineIntersection(const Line2_<T>& l1, const Line2_<T>& l2){
-    auto pd = l2.p - l1.p;  // diff of points
+template <typename T>
+inline boost::optional<T> lineIntersection(const Line2_<T>& l1,
+                                           const Line2_<T>& l2)
+{
+    auto pd = l2.p - l1.p; // diff of points
     auto den = l2.u(0) * l1.u(1) - l1.u(0) * l2.u(1);
     auto num = -l2.u(1) * pd(0) + l2.u(0) * pd(1);
-    return l1.p + (num / den) * l1.u;
+    if (den == 0) { return boost::none; }
+    T pt = l1.p + (num / den) * l1.u;
+    return pt;
 }
 
 /**

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -335,6 +335,50 @@ Point3 intersection( const Line3 & line, const legacy::Plane3 & plane );
 Point3 intersectionParams(const Line3 &line, const legacy::Plane3 &plane);
 
 
+/**
+* Plane represented in general form
+* Representation as (a,b,c,d) in equation: ax+by+cz+d=0
+*/
+struct Plane3
+{
+    math::Point3 n_;  // vector with (a,b,c) i.e. normal vector
+    double d_;
+
+    // Plane from parameters
+    Plane3(double a, double b, double c, double d) : n_(a, b, c), d_(d) { }
+
+    // Plane from point and normal
+    Plane3(const math::Point3d& pt, const math::Point3d& n)
+        : n_(n),
+          d_(-ublas::inner_prod(pt, n)) {};
+
+    // Plane from three points
+    Plane3(const math::Point3d& p1,
+           const math::Point3d& p2,
+           const math::Point3d& p3)
+        : Plane3(p1, crossProduct(p2 - p1, p3 - p1)) {};
+
+    // Plane from legacy representation (point-normal packed as Line3)
+    Plane3(const math::Line3& l) : Plane3(l.p, l.u) {};
+
+    // Returns a plane with opposite orientation
+    Plane3 opposite() const {
+        Plane3 opposite(*this);
+        opposite.n_ *= -1;
+        opposite.d_ *= -1;
+        return opposite;
+    }
+};
+
+/**
+ * Returns a distance of point to a plane (perpendicular)
+*/
+double pointPlaneDistance(const Point3 &p, const Plane3 &plane);
+
+/**
+ * Returns an orthogonal projection of a point to a plane
+ */
+Point3 pointPlaneProjection(const Point3 &p, const Plane3 &plane);
 
 /**
  * Returns a measure of triangular polyface regularity. Value of 1.0

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -270,8 +270,9 @@ double pointLineDistance(const Point3 &p, const Line3 &line);
 
 /**
  * Parametric plane, in euclidian 3D
+ * Legacy representation of plane by 3 points.
  */
-
+namespace legacy {
 struct Plane3 {
 
     Point3 p, u, v;
@@ -297,8 +298,6 @@ struct Plane3 {
     }
 };
 
-
-
 template <typename E, typename T>
 inline std::basic_ostream<E, T> & operator << (
         std::basic_ostream<E,T> & os,
@@ -307,11 +306,12 @@ inline std::basic_ostream<E, T> & operator << (
     os << plane.p << " + t * " << plane.u << " + s * " << plane.v;
     return os;
 }
+}  // namespace legacy
 
 
 /** line and plane intersection */
 
-Point3 intersection( const Line3 & line, const Plane3 & plane );
+Point3 intersection( const Line3 & line, const legacy::Plane3 & plane );
 
 /** line and plane intersection
  *  instead of point returns 3 coefficients:
@@ -319,7 +319,7 @@ Point3 intersection( const Line3 & line, const Plane3 & plane );
  *      * planes t-parameter
  *      * planes s-parameter
  */
-Point3 intersectionParams(const Line3 &line, const Plane3 &plane);
+Point3 intersectionParams(const Line3 &line, const legacy::Plane3 &plane);
 
 
 

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -266,6 +266,19 @@ inline T lineIntersection(const Line2_<T>& l1, const Line2_<T>& l2)
 }
 
 /**
+ * Line segment represented by start and end points
+ */
+template <typename T>
+struct Segment2_
+{
+    T p1, p2;
+
+    Segment2_(const T p1, const T p2) : p1(p1), p2(p2) {};
+};
+
+typedef Segment2_<Point2> Segment2;
+
+/**
  * Parametric line, in euclidian 3D
  */
 
@@ -393,6 +406,11 @@ double pointPlaneDistance(const Point3 &p, const Plane3 &plane);
  * Returns an orthogonal projection of a point to a plane
  */
 Point3 pointPlaneProjection(const Point3 &p, const Plane3 &plane);
+
+/**
+ * Returns a point of intersection between plane and line
+ */
+Point3 linePlaneIntersection(const Line3 &l, const Plane3 &plane);
 
 /**
  * Returns a line of intersection between two planes

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -243,13 +243,32 @@ inline T ccw(const Point2_<T> &a, const Point2_<T> &b, const Point2_<T> &c)
 
 /** Parametric line, in euclidian 2D
  */
-struct Line2 {
-    Point2 p, u;
 
-    Line2( const ublas::vector<double> p, const ublas::vector<double> u )
-        : p( p ), u( u ) {};
+template <typename T>
+struct Line2_
+{
+    T p, u;
+
+    Line2_(const T p, const T u) : p(p), u(u) {};
 };
 
+typedef Line2_<Point2> Line2;
+
+/** Returns a point where two lines `l1` and `l2` intersect.
+ * Point is inf
+ */
+template<typename T>
+inline T lineIntersection(const Line2_<T>& l1, const Line2_<T>& l2){
+    auto x1 = l1.p(0); auto y1 = l1.p(1);
+    auto x2 = l1.u(0); auto y2 = l1.u(1);
+    auto x3 = l2.p(0); auto y3 = l2.p(1);
+    auto x4 = l2.u(0); auto y4 = l2.u(1);
+    auto D = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+    return T(((x1 * y2 - y1 * x2) * (x3 - x4) - (x1 - x2) * (x3 * y4 - y3 * x4))
+                 / D,
+             ((x1 * y2 - y1 * x2) * (y3 - y4) - (y1 - y2) * (x3 * y4 - y3 * x4))
+                 / D);
+}
 
 /**
  * Parametric line, in euclidian 3D

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -38,7 +38,6 @@
 #include <algorithm>
 #include <array>
 
-#include <boost/optional/optional_io.hpp>
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/vector_proxy.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
@@ -256,18 +255,14 @@ struct Line2_
 typedef Line2_<Point2> Line2;
 
 /** Returns a point where two lines `l1` and `l2` intersect.
- * Returns none if lines are parallel (exactly).
  */
 template <typename T>
-inline boost::optional<T> lineIntersection(const Line2_<T>& l1,
-                                           const Line2_<T>& l2)
+inline T lineIntersection(const Line2_<T>& l1, const Line2_<T>& l2)
 {
-    auto pd = l2.p - l1.p; // diff of points
-    auto den = l2.u(0) * l1.u(1) - l1.u(0) * l2.u(1);
+    T pd = l2.p - l1.p; // diff of origins
     auto num = -l2.u(1) * pd(0) + l2.u(0) * pd(1);
-    if (den == 0) { return boost::none; }
-    T pt = l1.p + (num / den) * l1.u;
-    return pt;
+    auto den = l2.u(0) * l1.u(1) - l1.u(0) * l2.u(1);
+    return l1.p + (num / den) * l1.u;
 }
 
 /**
@@ -382,10 +377,10 @@ struct Plane3
 
     // Returns a plane with opposite orientation
     Plane3 opposite() const {
-        Plane3 opposite(*this);
-        opposite.n_ *= -1;
-        opposite.d_ *= -1;
-        return opposite;
+        Plane3 pl2(*this);
+        pl2.n_ *= -1;
+        pl2.d_ *= -1;
+        return pl2;
     }
 };
 

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -400,6 +400,11 @@ Point3 pointPlaneProjection(const Point3 &p, const Plane3 &plane);
 Line3 planeIntersection(const Plane3 &p1, const Plane3 &p2);
 
 /**
+ * Returns a point of intersection between three planes
+ */
+Point3 planeIntersection(const Plane3 &p1, const Plane3 &p2, const Plane3 &p3);
+
+/**
  * Returns a measure of triangular polyface regularity. Value of 1.0
  * indicates an equilateral triangle, value of 0.0 indicates a triangle
  * with at least one degenerate edge.

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -395,6 +395,11 @@ double pointPlaneDistance(const Point3 &p, const Plane3 &plane);
 Point3 pointPlaneProjection(const Point3 &p, const Plane3 &plane);
 
 /**
+ * Returns a line of intersection between two planes
+ */
+Line3 planeIntersection(const Plane3 &p1, const Plane3 &p2);
+
+/**
  * Returns a measure of triangular polyface regularity. Value of 1.0
  * indicates an equilateral triangle, value of 0.0 indicates a triangle
  * with at least one degenerate edge.

--- a/math/geometry.hpp
+++ b/math/geometry.hpp
@@ -259,15 +259,10 @@ typedef Line2_<Point2> Line2;
  */
 template<typename T>
 inline T lineIntersection(const Line2_<T>& l1, const Line2_<T>& l2){
-    auto x1 = l1.p(0); auto y1 = l1.p(1);
-    auto x2 = l1.u(0); auto y2 = l1.u(1);
-    auto x3 = l2.p(0); auto y3 = l2.p(1);
-    auto x4 = l2.u(0); auto y4 = l2.u(1);
-    auto D = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
-    return T(((x1 * y2 - y1 * x2) * (x3 - x4) - (x1 - x2) * (x3 * y4 - y3 * x4))
-                 / D,
-             ((x1 * y2 - y1 * x2) * (y3 - y4) - (y1 - y2) * (x3 * y4 - y3 * x4))
-                 / D);
+    auto pd = l2.p - l1.p;  // diff of points
+    auto den = l2.u(0) * l1.u(1) - l1.u(0) * l2.u(1);
+    auto num = -l2.u(1) * pd(0) + l2.u(0) * pd(1);
+    return l1.p + (num / den) * l1.u;
 }
 
 /**


### PR DESCRIPTION
The MR introduces the following changes:
- Moves the representation of a plane in 3D by three points to `math::legacy::Plane3` (as discussed with @ladislavhorky). 
- Adds a new representation of plane in general form (`ax+by+cz+d=0`)
- Introduces plane-related functions `pointPlaneDistance()`, `pointPlaneProjection()`, `linePlaneIntersection()`, `planeIntersection()`
- Introduces a numerically-stable function to compute angle between two vectors `angle()`
- Adds a `Line2_` template that allows to specify representation of point/direction vector in 2D line
- Introduces `lineIntersection()` function for 2D lines
- Adds a 2D line segment representation `Segment2_`