### PR TITLE
Replacing norm_2_square

### DIFF
--- a/math/geometry.cpp
+++ b/math/geometry.cpp
@@ -142,7 +142,7 @@ double pointPlaneDistance(const Point3& p, const Plane3& plane)
 Point3 pointPlaneProjection(const Point3& p, const Plane3& plane)
 {
     double k = (ublas::inner_prod(plane.n_, p) + plane.d_)
-               / ublas::norm_2_square(plane.n_);
+               / ublas::inner_prod(plane.n_, plane.n_);
 
     return Point3(p(0) - k * plane.n_(0),
                   p(1) - k * plane.n_(1),


### PR DESCRIPTION
Replacing `ublas::norm_2_square()` that is not present in older versions of uBLAS.