### PR TITLE
New functions to math and mathmodule

### DIFF
--- a/math/math.hpp
+++ b/math/math.hpp
@@ -35,6 +35,8 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <iterator>
+#include <functional>
 
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/vector_proxy.hpp>
@@ -235,7 +237,50 @@ void solve2x2(const MatrixType &mat, const VectorType &rhs, VectorType &result)
     result(1) = (mat(0,0)*rhs(1) - rhs(0)*mat(1,0)) * det;
 }
 
-                                                                               
+/**
+ * Calculate centroid
+ */
+template <typename T>
+T centroid(const std::vector<T>& points)
+{
+    T centroid(0, 0, 0);
+
+    for (const auto& point : points)
+    {
+        centroid += point;
+    }
+    centroid /= points.size();
+
+    return centroid;
+}
+
+/**
+ * Calculates covariance matrix
+ */
+template <typename T, typename M>
+void covMatrix(
+    const std::vector<T>& A,
+    M& matrix,
+    T (*func)(const T&, const T&)
+    = [](const T& a, const T& b) -> T { return a - b; })
+{
+    size_t recordSize = A[0].size();
+    matrix = M(recordSize, recordSize);
+
+    for (std::size_t n = 0; n < A.size(); ++n)
+    {
+        T x(func(A[n], centroid(A)));
+        for (size_t i = 0; i < recordSize; ++i)
+        {
+            for (size_t j = 0; j < recordSize; ++j)
+            {
+                if(!n) matrix(i, j) = 0;
+                matrix(i, j) += x(i) * x(j);
+            }
+        }
+    }
+}
+
 } // namespace math
 
 #endif // MATH_MATH_HPP

--- a/math/math.hpp
+++ b/math/math.hpp
@@ -35,8 +35,6 @@
 
 #include <algorithm>
 #include <stdexcept>
-#include <iterator>
-#include <functional>
 
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/vector_proxy.hpp>

--- a/math/python/mathmodule.cpp
+++ b/math/python/mathmodule.cpp
@@ -39,6 +39,7 @@
 #include <boost/python/slice.hpp>
 #include <boost/python/call.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include "boost/python/numpy.hpp"
 
 #include <stdint.h>
 
@@ -57,6 +58,7 @@
 #include "../transform.hpp"
 
 namespace bp = boost::python;
+namespace bn = boost::python::numpy;
 
 namespace math { namespace py {
 
@@ -142,7 +144,7 @@ bp::class_<Point2_<T>> point2(const char *name, const char *listName)
     using namespace bp;
     auto cls(point<T, math::Point2_<T>, math::Extents2_<T>>(name, listName));
     cls.def(init<T, T>());
-    return cls;
+    cls.def(init<const math::Point3_<T>&>());
 }
 
 // point3
@@ -153,6 +155,7 @@ bp::class_<Point3_<T>> point3(const char *name, const char *listName)
     using namespace bp;
     auto cls(point<T, math::Point3_<T>, math::Extents3_<T>>(name, listName));
     cls.def(init<T, T, T>());
+    cls.def(init<const math::Point2_<T>&>());
     return cls;
 }
 
@@ -223,6 +226,12 @@ auto Extents_size(const Extents &extents)
     return math::size(extents);
 }
 
+template <typename Extents>
+auto Extend(const Extents &extents, const float& value)
+{
+    return extents + value;
+}
+
 template <typename T>
 bp::class_<Extents2_<T>> extents2(const char *name)
 {
@@ -239,6 +248,7 @@ bp::class_<Extents2_<T>> extents2(const char *name)
         .def(init<T, T, T, T>())
         .def("__init__", make_constructor(&py::invalidExtents<Extents>))
 
+        .def("__add__", &py::Extend<Extents>)
         .def("__repr__", &py::repr_from_ostream<Extents>)
         .def_readwrite("ll", &Extents::ll)
         .def_readwrite("ur", &Extents::ur)
@@ -270,6 +280,7 @@ bp::class_<Extents3_<T>> extents3(const char *name)
         .def(init<T, T, T, T, T, T>())
         .def("__init__", make_constructor(&py::invalidExtents<Extents>))
 
+        .def("__add__", &py::Extend<Extents>)
         .def("__repr__", &py::repr_from_ostream<Extents>)
         .def_readwrite("ll", &Extents::ll)
         .def_readwrite("ur", &Extents::ur)

--- a/math/python/mathmodule.cpp
+++ b/math/python/mathmodule.cpp
@@ -39,7 +39,6 @@
 #include <boost/python/slice.hpp>
 #include <boost/python/call.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-#include "boost/python/numpy.hpp"
 
 #include <stdint.h>
 
@@ -58,7 +57,6 @@
 #include "../transform.hpp"
 
 namespace bp = boost::python;
-namespace bn = boost::python::numpy;
 
 namespace math { namespace py {
 
@@ -145,6 +143,7 @@ bp::class_<Point2_<T>> point2(const char *name, const char *listName)
     auto cls(point<T, math::Point2_<T>, math::Extents2_<T>>(name, listName));
     cls.def(init<T, T>());
     cls.def(init<const math::Point3_<T>&>());
+    return cls;
 }
 
 // point3

--- a/math/python/mathmodule.cpp
+++ b/math/python/mathmodule.cpp
@@ -226,7 +226,7 @@ auto Extents_size(const Extents &extents)
 }
 
 template <typename Extents>
-auto Extend(const Extents &extents, const float& value)
+Extents Extend(const Extents &extents, const float& value)
 {
     return extents + value;
 }


### PR DESCRIPTION
Added covariance matrix function that can accepts `eigen::Matrix`,`math::Matrix` and `cv::Mat`. With that centroid function was needed.

Few "upgrades" to mathmodule for better conversions.