### PR TITLE
math::update(...) modifies updateee only if updater is valid

### DIFF
--- a/math/geometry_core.hpp
+++ b/math/geometry_core.hpp
@@ -758,8 +758,10 @@ inline void update(Extents2_<T> &e, const Point3_<T> &p) {
 
 template <typename T>
 inline void update(Extents2_<T> &e, const Extents2_<T> &other) {
-    update(e, other.ll);
-    update(e, other.ur);
+    if (valid(other)) {
+        update(e, other.ll);
+        update(e, other.ur);
+    }
 }
 
 template <typename P, typename R, typename T>
@@ -953,8 +955,10 @@ inline void update(Extents3_<T> &e, const Point3_<T> &p) {
 
 template <typename T>
 inline void update(Extents3_<T> &e, const Extents3_<T> &other) {
-    update(e, other.ll);
-    update(e, other.ur);
+    if (valid(other)) {
+        update(e, other.ll);
+        update(e, other.ur);
+    }
 }
 
 template <typename T>


### PR DESCRIPTION
Original code indiscriminately injected updater endpoints into upadatee and produced nonsensical extents, for example:

```
Extents2 updatee = ((0, 0), (1, 1))
Extents2 updater =(([1000, 1000), (-1000, -1000));  // maximum smaller then minimum -> invalid extents

update(updatee, updater);

// result: ((-1000, -1000), (1000, 1000))
```

Fixed code check for updater's validity.