### PR TITLE
added roundup(x): half-way cases are rounded up/towards infinity

### DIFF
--- a/math/math.hpp
+++ b/math/math.hpp
@@ -279,7 +279,20 @@ void covMatrix(
     }
 }
 
+/** Templatized 1/2 for float and double.
+ */
+template <typename T> constexpr T OneHalf;
+template <> inline constexpr double OneHalf<double> = 0.5;
+template <> inline constexpr float OneHalf<float> = 0.5f;
+
+/** Floating point rounding with half-way cases rounded up (towards positive
+ *  infinity)
+ */
+template <typename T>
+T roundup(T value) {
+    return std::floor(value + OneHalf<T>);
+}
+
 } // namespace math
 
 #endif // MATH_MATH_HPP
-      


### PR DESCRIPTION
Unline `std::round` that rounds half-way cases away from zero, `math::roundup` rounds half-way cases up (or towards infinity)

Example:
| value | std::round | math::roundup |
| -----:| ----------:|--------------:|
|  -1.5 |         -2 |            -1 |
|  -0.5 |         -1 |             0 |
|   0.5 |          1 |             1 |
|   1.5 |          2 |             2 |

NB: Purely organic function, no glyphosate used.