### PR TITLE
Reworked I/O

### DIFF
--- a/math/CMakeLists.txt
+++ b/math/CMakeLists.txt
@@ -42,3 +42,6 @@ buildsys_library(math)
 target_link_libraries(math ${MODULE_LIBRARIES} ${math_EXTRA_LIBS})
 target_compile_definitions(math PRIVATE ${MODULE_DEFINITIONS})
 
+if(TARGET service)
+  add_subdirectory(tools EXCLUDE_FROM_ALL)
+endif()

--- a/math/CMakeLists.txt
+++ b/math/CMakeLists.txt
@@ -1,5 +1,5 @@
 # bump version here
-set(math_VERSION 1.11)
+set(math_VERSION 1.12)
 
 set(math_EXTRA_DEPENDS)
 set(math_EXTRA_DEFINITIONS)
@@ -14,7 +14,7 @@ endif()
 
 
 define_module(LIBRARY math=${math_VERSION}
-  DEPENDS dbglog>=1.7 utility>=1.41 Boost
+  DEPENDS dbglog>=1.7 utility>=1.47 Boost
   ${math_EXTRA_DEPENDS}
   DEFINITIONS ${math_EXTRA_DEFINITIONS})
 

--- a/math/detail/size3.inline.hpp
+++ b/math/detail/size3.inline.hpp
@@ -75,13 +75,67 @@ operator<<(std::basic_ostream<CharT, Traits> &os, const Size3_<T> &s)
     return os << s.width << "x" << s.height << "x" << s.depth;
 }
 
+#ifdef MATH_CAN_USE_BOOST_SPIRIT
 template<typename CharT, typename Traits, typename T>
 inline std::basic_istream<CharT, Traits>&
 operator>>(std::basic_istream<CharT, Traits> &is, math::Size3_<T> &s)
 {
-    return is >> s.width >> utility::expect('x') >> s.height
-              >> utility::expect('x') >> s.depth;
+    using boost::spirit::qi::auto_;
+    using boost::spirit::qi::omit;
+    using boost::spirit::qi::phrase_match;
+    using boost::spirit::ascii::blank;
+    using boost::spirit::lexeme;
+    using boost::spirit::qi::skip_flag;
+
+    typename std::basic_istream<CharT, Traits>::sentry sentry(is);
+
+    boost::io::ios_flags_saver ifs(is);
+    is.unsetf(std::ios::skipws);
+
+    is >> phrase_match(lexeme[auto_ >> omit['x'] >> auto_
+                              >> omit['x'] >> auto_]
+                       , blank, skip_flag::dont_postskip
+                       , s.width, s.height, s.depth);
+
+    return is;
 }
+
+template<typename CharT, typename Traits, typename T>
+inline std::basic_istream<CharT, Traits>&
+operator>>(std::basic_istream<CharT, Traits> &is
+           , math::Size3_<boost::rational<T>> &s)
+{
+    using boost::spirit::qi::auto_;
+    using boost::spirit::qi::omit;
+    using boost::spirit::qi::phrase_match;
+    using boost::spirit::ascii::blank;
+    using boost::spirit::lexeme;
+    using boost::spirit::qi::skip_flag;
+
+    typename std::basic_istream<CharT, Traits>::sentry sentry(is);
+
+    boost::io::ios_flags_saver ifs(is);
+    is.unsetf(std::ios::skipws);
+
+    std::pair<T, T> width, height, depth;
+    is >> phrase_match(lexeme[auto_ >> omit['/'] >> auto_
+                              >> omit['x']
+                              >> auto_ >> omit['/'] >> auto_
+                              >> omit['x']
+                              >> auto_ >> omit['/'] >> auto_]
+                       , blank, skip_flag::dont_postskip
+                       , width.first, width.second
+                       , height.first, height.second
+                       , depth.first, depth.second);
+    if (is) {
+        s.width.assign(width.first, width.second);
+        s.height.assign(height.first, height.second);
+        s.depth.assign(depth.first, depth.second);
+    }
+
+    return is;
+}
+#endif
 
 template <typename T, typename U>
 inline auto operator*(const math::Size3_<T> &l, const math::Size3_<U> &r)

--- a/math/geometry_core.hpp
+++ b/math/geometry_core.hpp
@@ -1029,7 +1029,8 @@ operator>>(std::basic_istream<CharT, Traits> &is, Viewport2_<T> &v)
     utility::parseToken
         (is
          , (auto_ >> omit['x'] >> auto_
-            >> -(char_("+-") >> auto_ >> char_("+-") >> auto_))
+            >> -(char_("+-") >> !char_("+-") >> auto_
+                 >> char_("+-") >> !char_("+-") >> auto_))
          , v.width, v.height, shift);
 
     if (is && shift) {

--- a/math/math.hpp
+++ b/math/math.hpp
@@ -282,8 +282,14 @@ void covMatrix(
 /** Templatized 1/2 for float and double.
  */
 template <typename T> constexpr T OneHalf;
+
+#ifdef __cpp_inline_variables
 template <> inline constexpr double OneHalf<double> = 0.5;
 template <> inline constexpr float OneHalf<float> = 0.5f;
+#else
+template <> constexpr double OneHalf<double> = 0.5;
+template <> constexpr float OneHalf<float> = 0.5f;
+#endif
 
 /** Floating point rounding with half-way cases rounded up (towards positive
  *  infinity)

--- a/math/tools/CMakeLists.txt
+++ b/math/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 define_module(BINARY math:tools
-  DEPENDS dbglog>=1.7 utility>=1.41 service
+  DEPENDS dbglog>=1.7 utility>=1.47 service
   math>=${math_VERSION})
 
 add_executable(math.io io.cpp)

--- a/math/tools/CMakeLists.txt
+++ b/math/tools/CMakeLists.txt
@@ -1,0 +1,8 @@
+define_module(BINARY math:tools
+  DEPENDS dbglog>=1.7 utility>=1.41 service
+  math>=${math_VERSION})
+
+add_executable(math.io io.cpp)
+buildsys_binary(math.io)
+target_link_libraries(math.io ${MODULE_LIBRARIES})
+target_compile_definitions(math.io PRIVATE ${MODULE_DEFINITIONS})

--- a/math/tools/io.cpp
+++ b/math/tools/io.cpp
@@ -120,6 +120,65 @@ bool MathIo::help(std::ostream &out, const std::string &what) const
 }
 
 template <typename T>
+bool lexicalCast(LexicalCast lc)
+{
+    try {
+        const auto value(boost::lexical_cast<T>(lc.value));
+        std::cout << "lexically cast " << lc.type << "(" << value << ")"
+                  << std::endl;
+    } catch (const boost::bad_lexical_cast&) {
+        return false;
+    }
+
+    return true;
+}
+
+int MathIo::useLexicalCast()
+{
+    const auto &lc(lexicalCast_.value());
+
+#define CASE(TYPE)                                                      \
+    case Type::TYPE:                                                    \
+        if (!lexicalCast<math::TYPE>(lc)) {                             \
+            std::cerr << "failed to parse " << lc.type                  \
+                      << std::endl;                                     \
+            return EXIT_FAILURE;                                        \
+        }                                                               \
+        break
+
+    switch (lc.type) {
+        CASE(Size2);
+        CASE(Size2i);
+        CASE(Size2ll);
+        CASE(Size2f);
+        CASE(Size2r);
+
+        CASE(Size3);
+        CASE(Size3i);
+        CASE(Size3ll);
+        CASE(Size3f);
+        CASE(Size3r);
+
+        CASE(Extents2);
+        CASE(Extents2i);
+        CASE(Extents2ll);
+        CASE(Extents2f);
+
+        CASE(Extents3);
+        CASE(Extents3i);
+        CASE(Extents3ll);
+        CASE(Extents3f);
+
+        CASE(Viewport2);
+        CASE(Viewport2i);
+        CASE(Viewport2f);
+    }
+#undef CASE
+
+    return EXIT_SUCCESS;
+}
+
+template <typename T>
 bool parse(std::istream &is, Type type)
 {
     T value;
@@ -131,12 +190,6 @@ bool parse(std::istream &is, Type type)
     std::cout << "parsed " << type << "(" << value << ")" << std::endl;
 
     return true;
-}
-
-int MathIo::useLexicalCast()
-{
-    // TODO: implement me
-    return EXIT_SUCCESS;
 }
 
 void state(const std::string &message, std::istream &is)
@@ -217,4 +270,3 @@ int main(int argc, char *argv[])
 {
     return MathIo()(argc, argv);
 }
-

--- a/math/tools/io.cpp
+++ b/math/tools/io.cpp
@@ -1,0 +1,220 @@
+#include "service/cmdline.hpp"
+#include "utility/buildsys.hpp"
+#include "utility/enum-io.hpp"
+
+#include "math/geometry_core.hpp"
+
+namespace po = boost::program_options;
+
+namespace {
+
+UTILITY_GENERATE_ENUM(Type,
+                      ((Size2))
+                      ((Size2i))
+                      ((Size2ll))
+                      ((Size2r))
+                      ((Size2f))
+
+                      ((Size3))
+                      ((Size3i))
+                      ((Size3ll))
+                      ((Size3r))
+                      ((Size3f))
+
+                      ((Extents2))
+                      ((Extents2i))
+                      ((Extents2ll))
+                      ((Extents2f))
+
+                      ((Extents3))
+                      ((Extents3i))
+                      ((Extents3ll))
+                      ((Extents3f))
+
+                      ((Viewport2))
+                      ((Viewport2i))
+                      ((Viewport2f))
+                      )
+
+struct LexicalCast {
+    Type type;
+    std::string value;
+
+    using optional = std::optional<LexicalCast>;
+
+    LexicalCast(Type type, std::string value)
+        : type(type), value(std::move(value))
+    {}
+};
+
+class MathIo : public service::Cmdline
+{
+public:
+    MathIo()
+        : Cmdline("math.io", BUILD_TARGET_VERSION
+                  , service::DISABLE_EXCESSIVE_LOGGING)
+    {
+    }
+
+private:
+    virtual void configuration(po::options_description &cmdline
+                               , po::options_description &config
+                               , po::positional_options_description &pd)
+        override;
+
+    virtual void configure(const po::variables_map &vars)
+        override;
+
+    virtual bool help(std::ostream &out, const std::string &what)
+        const override;
+
+    virtual int run() override;
+
+    int useLexicalCast();
+
+    int useStream();
+
+    LexicalCast::optional lexicalCast_;
+};
+
+void MathIo::configuration(po::options_description &cmdline
+                           , po::options_description &config
+                           , po::positional_options_description &pd)
+{
+    cmdline.add_options()
+        ("type", po::value<Type>()
+         , "Type when using boost::lexical_cast. "
+         "Must be used together with --value.")
+        ("value", po::value<std::string>()
+         , "Value when useing boost::lexical_cast. "
+         "Must be used together with --type.")
+        ;
+
+    pd
+        .add("type", 1)
+        .add("value", 1);
+
+    (void) config;
+}
+
+void MathIo::configure(const po::variables_map &vars)
+{
+    auto type(vars.count("type"));
+    auto value(vars.count("value"));
+    if (type != value) {
+        throw po::error("type and value must be used together");
+    }
+    if (type) {
+        lexicalCast_.emplace(vars["type"].as<Type>()
+                             , vars["value"].as<std::string>());
+    }
+}
+
+bool MathIo::help(std::ostream &out, const std::string &what) const
+{
+    if (what.empty()) {
+        out << R"RAW(math.io: test I/O operations on various libmath data types
+)RAW";
+    }
+    return false;
+}
+
+template <typename T>
+bool parse(std::istream &is, Type type)
+{
+    T value;
+    if (!(is >> value)) {
+        std::cout << "partial parse: <" << value << ">" << std::endl;
+        return false;
+    }
+
+    std::cout << "parsed " << type << "(" << value << ")" << std::endl;
+
+    return true;
+}
+
+int MathIo::useLexicalCast()
+{
+    // TODO: implement me
+    return EXIT_SUCCESS;
+}
+
+void state(const std::string &message, std::istream &is)
+{
+    std::cout << message;
+    if (is.good()) { std::cout << " good"; }
+    if (is.fail()) { std::cout << " fail"; }
+    if (is.bad()) { std::cout << " bad"; }
+    if (is.eof()) { std::cout << " eof"; }
+    std::cout << std::endl;
+}
+
+int MathIo::useStream()
+{
+    auto &is(std::cin);
+
+    Type type = {};
+    state("> start state:", is);
+
+    while (is >> type) {
+#define CASE(TYPE)                                                      \
+        case Type::TYPE:                                                \
+            if (!parse<math::TYPE>(is, type)) {                         \
+                std::cerr << "failed to parse " << type << std::endl;   \
+                continue;                                               \
+            }                                                           \
+            break
+
+        switch (type) {
+            CASE(Size2);
+            CASE(Size2i);
+            CASE(Size2ll);
+            CASE(Size2f);
+            CASE(Size2r);
+
+            CASE(Size3);
+            CASE(Size3i);
+            CASE(Size3ll);
+            CASE(Size3f);
+            CASE(Size3r);
+
+            CASE(Extents2);
+            CASE(Extents2i);
+            CASE(Extents2ll);
+            CASE(Extents2f);
+
+            CASE(Extents3);
+            CASE(Extents3i);
+            CASE(Extents3ll);
+            CASE(Extents3f);
+
+            CASE(Viewport2);
+            CASE(Viewport2i);
+            CASE(Viewport2f);
+        }
+#undef CASE
+
+        state("> after parse state:", is);
+    }
+
+    state("> end state:", is);
+
+    return (is ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+int MathIo::run()
+{
+    if (lexicalCast_) {
+        return useLexicalCast();
+    }
+
+    return useStream();
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    return MathIo()(argc, argv);
+}
+


### PR DESCRIPTION
Parsing reworked to use `utility::parseToken` that extracts while token and then parses via provided Boost.Spirit grammar.

Added `math.io` test tool to test parsing from stream and `boost::lexical_cast` from string, examples:

 * istream:
   ```
   > echo -e 'Extents2i 100,200:300,400 Size2 1x1 Size2r 10/5x1/3 Size3f 1.1x2.2x5 Extents2 0.1,0.2:0.3,0.4 Size2f 1.1x2.2 Viewport2 10x20-100+200 Viewport2 20x30+10+50 Viewport2 30x40-5-6' | ./bin/math.io
   > start state: good
   parsed Extents2i(100,200:300,400)
   > after parse state: good
   parsed Size2(1x1)
   > after parse state: good
   parsed Size2r(2/1x1/3)
   > after parse state: good
   parsed Size3f(1.1x2.2x5)
   > after parse state: good
   parsed Extents2(0.1,0.2:0.3,0.4)
   > after parse state: good
   parsed Size2f(1.1x2.2)
   > after parse state: good
   parsed Viewport2(10x20-100+200)
   > after parse state: good
   parsed Viewport2(20x30+10+50)
   > after parse state: good
   parsed Viewport2(30x40-5-6)
   > after parse state: good
   > end state: fail eof
   ```
* `boost::lexical_cast`:
   ```
   > ./bin/math.io Size2 "2x3"
   lexically cast Size2(2x3)
   > ./bin/math.io Size2 "x2x3"
   failed to parse Size2
   ```